### PR TITLE
Use Xtend 2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>2.12.0</version>
+			<version>2.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.aether</groupId>
@@ -175,7 +175,7 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>2.14.0</version>
+				<version>2.18.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -188,13 +188,6 @@
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.platform</groupId>
-						<artifactId>org.eclipse.equinox.common</artifactId>
-						<version>3.10.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 
 			<plugin>
@@ -240,3 +233,4 @@
 		</plugins>
 	</build>
 </project>
+


### PR DESCRIPTION
This PR fixes the build error complaining missing dependencies of the xtend build step.